### PR TITLE
Allow optional custom filenames for output

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@ var Elixir = require('laravel-elixir');
 
 var config = Elixir.config;
 
-Elixir.extend('svgstore', function(baseDir, output) {
+Elixir.extend('svgstore', function(baseDir, output, filename) {
   config.svg = {
     folder: 'svg',
     outputFolder: 'svg'
   };
 
-  var paths = prepGulpPaths('**/*.svg', baseDir, output);
+  var paths = prepGulpPaths('**/*.svg', baseDir, output, filename);
 
   new Elixir.Task('svgstore', function () {
     this.log(paths.src, paths.output);
@@ -53,10 +53,11 @@ Elixir.extend('svgstore', function(baseDir, output) {
  * @param  {string|array} src
  * @param  {string|null} baseDir
  * @param  {string|null}  output
+ * @param  {string|null}  filename
  * @return {object}
  */
-var prepGulpPaths = function(src, baseDir, output) {
+var prepGulpPaths = function(src, baseDir, output, filename) {
   return new Elixir.GulpPaths()
     .src(src, baseDir || config.get('assets.svg.folder'))
-    .output(output || config.get('public.svg.outputFolder'), 'sprites.svg');
+    .output(output || config.get('public.svg.outputFolder'), filename || 'sprites.svg');
 };

--- a/readme.md
+++ b/readme.md
@@ -25,13 +25,13 @@ elixir(function(mix) {
 By default, it will look for .svg files within ```resources/assets/svg/``` and outputs
 ```sprites.svg``` to ```public/svg/```.
 
-You can optionally pass a source directory and an output directory:
+You can optionally pass a source directory, an output directory, and a custom filename:
 
 ```js
 ...
 
 elixir(function(mix) {
-  mix.svgstore('resources/assets/icons', 'public/icons');
+  mix.svgstore('resources/assets/icons', 'public/sprites/', 'icons.svg');
 });
 ```
 


### PR DESCRIPTION
Love the custom output option, so I added another for filenames.

This makes it possible to mix multiple sprites to the same directory:

```
mix.svgstore('resources/assets/icons/global', 'public/sprites/', 'global.svg');
mix.svgstore('resources/assets/icons/features', 'public/sprites/', 'features.svg');
...
```

When left blank, the filename sticks to the default, `sprites.svg`, so there are no breaking changes.
