### PR TITLE
Allow optional custom svgmin plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var Elixir = require('laravel-elixir');
 
 var config = Elixir.config;
 
-Elixir.extend('svgstore', function(baseDir, output, filename) {
+Elixir.extend('svgstore', function(baseDir, output, filename, plugins) {
   config.svg = {
     folder: 'svg',
     outputFolder: 'svg'
@@ -24,13 +24,13 @@ Elixir.extend('svgstore', function(baseDir, output, filename) {
         var prefix = path.basename(file.relative, path.extname(file.relative));
 
         return {
-          plugins: [{
+          plugins: plugins || [{
             cleanupIDs: {
               prefix: prefix + '-',
               minify: true
             }
           }]
-        }
+        };
       }))
       .pipe(svgstore())
       .on('error', function (e) {

--- a/readme.md
+++ b/readme.md
@@ -25,20 +25,30 @@ elixir(function(mix) {
 By default, it will look for .svg files within ```resources/assets/svg/``` and outputs
 ```sprites.svg``` to ```public/svg/```.
 
-You can optionally pass a source directory, an output directory, and a custom filename:
+You can optionally pass the following:
+
+- source directory
+- output directory
+- custom filename
+- custom [svgmin plugins](https://github.com/ben-eb/gulp-svgmin#plugins)
 
 ```js
 ...
 
+var svgminPlugins = [
+  { removeUnknownsAndDefaults: false },
+  { removeUselessStrokeAndFill: false },
+  { collapseGroups: false }
+];
+
 elixir(function(mix) {
-  mix.svgstore('resources/assets/icons', 'public/sprites/', 'icons.svg');
+  mix.svgstore('resources/assets/icons', 'public/sprites/', 'icons.svg', svgminPlugins);
 });
 ```
 
 ## In Your Blade Templates
 
 If you started with a file called ```myicon.svg``` you can display that icon like this:
-
 
 ```html
 <svg style="width: .75em; height: .75em">

--- a/readme.md
+++ b/readme.md
@@ -22,15 +22,26 @@ elixir(function(mix) {
 
 ## Usage
 
-By default, it will look for .svg files within ```resources/assets/svg/``` and outputs
-```sprites.svg``` to ```public/svg/```.
+By default, it will look for .svg files within ```resources/assets/svg/``` and output
+```sprites.svg``` to ```public/svg/```, using the following [svgmin plugins](https://github.com/ben-eb/gulp-svgmin#plugins):
 
-You can optionally pass the following:
+```
+...
+
+plugins: [{
+  cleanupIDs: {
+    prefix: prefix + '-',
+    minify: true
+  }
+}]
+```
+
+You can optionally pass custom arguments for:
 
 - source directory
 - output directory
-- custom filename
-- custom [svgmin plugins](https://github.com/ben-eb/gulp-svgmin#plugins)
+- filename
+- [svgmin plugins](https://github.com/ben-eb/gulp-svgmin#plugins)
 
 ```js
 ...


### PR DESCRIPTION
Got another custom option to add for svgmin plugins.

Realized that my build needed some different options, so I just tacked on another argument:

```
mix.svgstore('resources/assets/icons/global', 'public/sprites/', 'global.svg', [
  { removeUnknownsAndDefaults: false },
  { removeUselessStrokeAndFill: false },
  { collapseGroups: false }
]);
```

When left blank, it uses the original default plugins you had set.

Ideally, I'd clean this up a bit by using the Elixir config to handle settings like this. But for now, this gets the job done.

Oh, and in case anybody wanted to set custom plugins but still use the default source/output/filename, you can just pass `null` for those first couple of arguments. Like so:

```
mix.svgstore(null, null, null, [
  { removeUnknownsAndDefaults: false },
  { removeUselessStrokeAndFill: false },
  { collapseGroups: false }
]);
```

Again, this could be cleaned up but wanted to get this first pass in.
